### PR TITLE
Add Istanbul test coverage tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "timesync",
+  "version": "0.0.0",
+  "description": "TimeSync time tracker implemented in js",
+  "main": "app.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "start": "node ./src/app.js",
+    "migrations": "knex migrate:latest",
+    "recreate": "rm dev.sqlite3 && knex migrate:latest",
+    "linter": "jshint ./src ./tests && jscs ./src ./tests",
+    "coverage": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests",
+    "fixtures": "node ./scripts/load_fixtures.js",
+    "test": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && mocha tests/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tschuy/timesync.git"
+  },
+  "keywords": [
+    "time",
+    "tracker"
+  ],
+  "author": "OSU Open Source Lab <support@osuosl.org>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/tschuy/timesync/issues"
+  },
+  "dependencies": {
+    "body-parser": "^1.12.3",
+    "expect.js": "^0.3.1",
+    "express": "^4.12.3",
+    "knex": "^0.8.6",
+    "mocha": "^2.2.4",
+    "sqlite3": "^3.0.8"
+  },
+  "devDependencies": {
+    "istanbul": "^0.3.17",
+    "jscs": "^1.13.1",
+    "jshint": "^2.8.0",
+    "request": "^2.55.0",
+    "supertest": "^1.0.1",
+    "sql-fixtures": "^0.11.0"
+  }
+}


### PR DESCRIPTION
![Istanbul skyline](http://photos.travellerspoint.com/403576/large_IMG_1769_tonemapped.jpg)

```
(timesync)iankronquist@puppettop:(timesync)(ian/istanbul-sokaklari) → npm run coverage

> timesync@0.0.0 coverage /Users/iankronquist/gg/timesync
> export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests

Using environment: mocha
Batch 1 run: 1 migrations 
/Users/iankronquist/gg/timesync/migrations/20150101000000_00.js


App now listening on 8851
  Endpoints
    GET /times
      ✓ should return all times in the database
    GET /times/:id
      ✓ should return times by id
      ✓ should fail with Object not found error
    GET /users
      ✓ should return all users in the database
    GET /activities
      ✓ should return all activities in the database
    GET /activities/:slug
      ✓ should return activities by slug
      ✓ should fail with invalid slug error
    GET /projects
      ✓ should return all projects in the database
    GET /projects/:slug
      ✓ should return projects by slug
      ✓ should fail with invalid slug error


  10 passing (460ms)

=============================================================================
Writing coverage object [/Users/iankronquist/gg/timesync/coverage/coverage.json]
Writing coverage reports at [/Users/iankronquist/gg/timesync/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 89.22% ( 149/167 )
Branches     : 63.16% ( 24/38 )
Functions    : 79.07% ( 34/43 )
Lines        : 89.22% ( 149/167 )
================================================================================

```
