### PR TITLE
Change project owner to creator

### DIFF
--- a/source/usage/administration.rst
+++ b/source/usage/administration.rst
@@ -22,7 +22,7 @@ easier:
 * a ``uri``: a uri linking to the project's homepage.
 * a ``name``: this is the full name of the project that should be displayed
   to the user.
-* an ``creator``: this should be the original creator of the project, generally
+* a ``creator``: this should be the original creator of the project, generally
   an admin user. The creator acts as the default project manager and is the
   only person that can modify the project until they (or another admin) assigns
   project managers.

--- a/source/usage/administration.rst
+++ b/source/usage/administration.rst
@@ -22,8 +22,10 @@ easier:
 * a ``uri``: a uri linking to the project's homepage.
 * a ``name``: this is the full name of the project that should be displayed
   to the user.
-* an ``owner``: this should be the user responsible for the project, generally
-  an admin user. This owner is the only person that can modify the project.
+* an ``creator``: this should be the original creator of the project, generally
+  an admin user. The creator acts as the default project manager and is the
+  only person that can modify the project until they (or another admin) assigns
+  project managers.
 * a list of ``slugs``: these are generally short things that people can refer
   to the project with. If your project is named Protein Geometry Database,
   it makes users' lives easier to only need to type in ``pgd`` when submitting


### PR DESCRIPTION
With the addiction of user roles, the api docs need an update. The relevant difference here is that the title of project 'owner' is being changed to 'creator'. If everyone is in agreement about this change, all instances of 'owner' in timesync-node will be changed to 'creator' to reflect the api documentation.

Note that the timesync gitsubmodule was deleted from timesync-node's develop branch in an earlier merge. Someone should add that back.
