### PR TITLE
Add soft-delete documentation.

### DIFF
--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -90,6 +90,8 @@ GET Endpoints
          "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
          "revision": 2,
          "id": 1
+         "deleted_at": null,
+         "parent": null
       },
       {...},
       ...
@@ -106,7 +108,9 @@ GET Endpoints
        "owner": "example-user",
        "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
        "revision": 4,
-       "id": 1
+       "id": 1,
+       "deleted_at": null,
+       "parent": null
     }
 
 *GET /activities*
@@ -120,6 +124,8 @@ GET Endpoints
            "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
            "revision": 1,
            "id": 1
+           "deleted_at": null,
+           "parent": null
         },
         {...}
     ]
@@ -133,7 +139,9 @@ GET Endpoints
        "slugs":["doc", "docs"],
        "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
        "revision": 5,
-       "id": 1
+       "id": 1,
+       "deleted_at": null,
+       "parent": null
     }
 
 *GET /times*
@@ -154,6 +162,8 @@ GET Endpoints
         "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
         "revision": 1,
         "id": 1
+        "deleted_at": null,
+        "parent": null
       },
       {...}
     ]
@@ -174,23 +184,46 @@ GET Endpoints
       "updated_at":2014-06-13,
       "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
       "revision": 3,
-      "id": 1
+      "id": 1,
+      "deleted_at": null,
+      "parent": null
     }
 
-In addition, the endpoint at ``/times`` also supports several querystring parameters: user,
-project, activity, and date range. These are accessed via ``/times?user=:username``,
-``/times?project=:projectslug``, ``/times?activity=:activityslug``, ``/times?start=:date``, and
-``/times?end=:date`` (note that dates are in ISO-8601 format). When multiple different
-parameters are used, they narrow down the result set (for example,
-``/times?user=example-user&activity=dev`` will return all time entries which were entered by
-example-user AND which were spent doing development). When the same parameter is repeated,
-they expand the result set (for example, ``/times?activity=gwm&activity=pgd`` will return all
-time entries which were either for gwm OR pgd). Date ranges are inclusive on both ends.
+In addition, the endpoint at ``/times`` also supports several querystring
+parameters:
 
-If a query parameter is provided with a bad value (e.g. invalid slug, or date not in ISO
-8601 format), a Bad Query Value error is returned. Any query parameter other than those
-specified in this document will be ignored. If multiple ``start`` or ``end`` parameters are provided,
-the first one sent is used. If a query parameter is not provided, it defaults to 'all values'.
+* user,
+* project,
+* activity, and
+* date range.
+
+These are accessed via
+
+* ``/times?user=:username``: Filters based on username
+* ``/times?project=:projectslug``: Filters based on project slugs
+* ``/times?activity=:activityslug``: Filters based on activity slug
+* ``/times?start=:date``: Filters to dates after and including the given date.
+* ``/times?end=:date``:  Filters to dates after and including the given date.
+* ``/times/?archived=:bool``: Filters on objects with ``deleted_at`` set to
+  ``null`` or a date.
+
+.. note:: Dates are in ISO-8601 format.
+
+When multiple different parameters are used, they narrow down the result set
+(for example, ``/times?user=example-user&activity=dev`` will return all time
+entries which were entered by example-user AND which were spent doing
+development). When the same parameter is repeated, they expand the result set
+(for example, ``/times?activity=gwm&activity=pgd`` will return all time entries
+which were either for gwm OR pgd). Date ranges are inclusive on both ends.
+
+If a query parameter is provided with a bad value (e.g. invalid slug, or date
+not in ISO-8601 format), a Bad Query Value error is returned.
+
+Any query parameter other than those specified in this document will be
+ignored.
+
+If multiple ``start`` or ``end`` parameters are provided, the first one sent is
+used. If a query parameter is not provided, it defaults to 'all values'.
 
 The endpoint at ``/times/:uuid`` also supports several querystring parameters:
 
@@ -248,7 +281,9 @@ Response body:
        "name":"TimeSync API",
        "slugs":["timesync", "time"],
        "owner": "example-2",
-       "id": 1
+       "id": 1,
+       "updated_at":null,
+       "parent":null
     }
 
 *POST /activities/*
@@ -275,7 +310,9 @@ Response body:
       "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
       "date_worked":null,
       "created_at":2014-09-18,
-      "updated_at":null
+      "updated_at":null,
+      "deleted_at":null,
+      "parent":null,
     }
 
 Likewise, if you'd like to edit an existing object, POST to

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -91,12 +91,12 @@ There are three variables in all objects that assist in an audit process
   of a new object revision).
 * ``deleted_at``: When the DELETE operation is performed on an object it's
   ``deleted_at`` field is set to the date it was deleted. Historical
-  (``parent``) copies of an object do not have ``deleted_at`` set unless the
+  (``parents``) copies of an object do not have ``deleted_at`` set unless the
   object was deleted for a given historical copy (and later un-deleted).
 
 
 **To view the audit trail of an object pass the** ``?revisions=true``
-**parameter to any endpoint and insepct the 'parent' variable (a list of
+**parameter to any endpoint and insepct the 'parents' variable (a list of
 object revisions).**
 
 -------------
@@ -227,7 +227,7 @@ These are accessed via
 * ``/times?start=:date``: Filters to dates after and including the given date.
 * ``/times?end=:date``:  Filters to dates after and including the given date.
 * ``/times/?revisions=:bool``: Returns objects and an audit list for that
-  object in the form of a list ``parent``.
+  object in the form of a list ``parents``.
 
 
 For example:
@@ -246,7 +246,7 @@ For example:
       "created_at": 2015-04-17,
       "deleted_at": null,
       "updated_at": null,
-      "parent":
+      "parents":
       [
         {
           "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
@@ -281,7 +281,7 @@ For example:
       "uuid": "aa800862-e852-4a40-8882-9b4a79aa3015",
       "deleted_at": null,
       "revision":2,
-      "parent":
+      "parents":
         [
           {
             "duration":20,
@@ -313,7 +313,7 @@ For example:
       "deleted_at": null,
       "updated_at": 2014-04-18,
       "revision":2,
-      "parent":
+      "parents":
         [
           {
             "name":"Testing Infrastructure",
@@ -587,7 +587,7 @@ The following content is checked by the API for validity:
 
 .. note::
 
-   When an object is updated it's ``parent`` is soft-deleted and a copy is
+   When an object is updated it's ``parents`` is soft-deleted and a copy is
    created with the new information. This results in the object having an
    incremented 'revision' field the updated information specifed in the POST
    request.

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -255,9 +255,6 @@ POST Endpoints
 To add a new object, POST to */<object name>/* with a JSON body. The response
 body will contain the object in the same manner as the GET endpoints above.
 
-In general, the only difference between the request body and the response body
-will be the inclusion of the object's ``id``.
-
 *POST /projects/*
 ~~~~~~~~~~~~~~~~~
 
@@ -289,6 +286,8 @@ Response body:
 *POST /activities/*
 ~~~~~~~~~~~~~~~~~~~
 
+Request body:
+
 .. code-block:: javascript
 
     {
@@ -296,19 +295,53 @@ Response body:
        "slugs":["qa", "test"]
     }
 
+Response body:
+
+.. code-block:: javascript
+
+    {
+       "name":"Quality Assurance/Testing",
+       "slugs":["qa", "test"],
+       "id": 1,
+       "deleted_at": null,
+       "parent": null
+    }
+
+
 *POST /times/*
 ~~~~~~~~~~~~~~
+
+Request body:
 
 .. code-block:: javascript
 
     {
       "duration":12,
       "user": "example-2",
-      "project": "",
+      "project": "Ganeti Web Manager",
       "activities": ["gwm", "ganeti"],
-      "notes":"",
+      "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
-      "date_worked":null,
+      "date_worked":2014-04-17,
+    }
+
+Response body:
+
+.. code-block:: javascript
+
+    {
+      "duration":12,
+      "user": "example-user",
+      "project": "Ganeti Web Manager",
+      "activities": ["docs", "planning"],
+      "notes":"Worked on documentation toward settings configuration.",
+      "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
+      "date_worked":2014-04-17,
+      "created_at":2014-04-17,
+      "updated_at":null,
+      "deleted_at":null,
+      "parent":null
+      "id": 1,
     }
 
 Likewise, if you'd like to edit an existing object, POST to
@@ -320,6 +353,8 @@ body will contain the saved object, as shown above.
 *POST /projects/<slug>*
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+Request body:
+
 .. code-block:: javascript
 
     {
@@ -327,17 +362,49 @@ body will contain the saved object, as shown above.
        "slugs":["webmgr", "gwm"],
     }
 
-*POST /activities/<slug>*
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Response body:
 
 .. code-block:: javascript
 
     {
-       "slugs":["testing", "test"]
+      "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
+      "name":"Ganeti Webmgr",
+      "slugs":["webmgr", "gwm"],
+      "owner": "example-user",
+      "id": 2,
+      "deleted_at": null,
+      "parent": 1
+    }
+
+*POST /activities/<slug>*
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Request body:
+
+
+.. code-block:: javascript
+
+    {
+      "slugs":["testing", "test"]
+    }
+
+Response body:
+
+.. code-block:: javascript
+
+    {
+      "name":"Testing Infra",
+      "slugs":["testing", "test"],
+      "id": 4,
+      "deleted_at": null,
+      "parent": 2
     }
 
 *POST /times/<uuid>*
 ~~~~~~~~~~~~~~~~~~
+
+Request body:
+
 
 .. code-block:: javascript
 
@@ -345,6 +412,26 @@ body will contain the saved object, as shown above.
       "duration":20,
       "date_worked":"2015-04-17"
     }
+
+Response body:
+
+.. code-block:: javascript
+
+    {
+      "duration":20,
+      "user": "example-user",
+      "project": "gwm",
+      "activities": ["doc", "research"],
+      "notes":"Worked on documentation toward settings configuration.",
+      "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
+      "date_worked":2015-04-17,
+      "created_at":2014-06-12,
+      "updated_at":2015-04-18,
+      "id": 3,
+      "deleted_at": null,
+      "parent": 1
+    }
+
 
 In the case of a foreign key (such as project on a time) that does not point to
 a valid object or a malformed object sent in the request, an Object Not Found
@@ -359,6 +446,12 @@ The following content is checked by the API for validity:
 * The Project must exist in the database.
 * The owner of the request must be the user in the time submission.
     * This is authorization not authentication.
+
+.. note::
+
+    While they won't produce an error, empty data structures such as ``""`` and
+    ``[]`` will be ignored when sent to the api as the value of an object
+    variable.
 
 ----------------
 

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -13,9 +13,9 @@ Below are the API specs for the TimeSync project.
 Connection
 ----------
 
-All requests will be made via HTTPS. Available methods are GET to request an
-object, POST to create and/or edit a new object, and DELETE to remove an
-object.
+All requests will be made via HTTPS. Available methods are ``GET`` to request
+an object, ``POST`` to create and/or edit a new object, and ``DELETE`` to
+remove an object.
 
 ------
 
@@ -24,11 +24,14 @@ Format
 
 Responses will be returned in standard JSON format. Multiple results will be
 sent as a list of JSON objects. Order of results is not guaranteed. Single
-results will be a single JSON object.
+results will be returned as a single JSON object.
 
-Throughout this API, any form of dates will use a simplified ISO-8601 format,
-as `defined by ECMA International.
-<http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15>`_
+
+.. note::
+
+    Throughout this API, any form of dates will use a simplified ISO-8601
+    format, as `defined by ECMA International.
+    <http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15>`_
 
 --------
 
@@ -60,18 +63,19 @@ a very specific format:
 Revisions
 ---------
 
-When an object is first created, it is assigned a tracking ID. This is a UUID which will
-refer to all versions of the same object.
+When an object is first created, it is assigned a tracking ID. This is a UUID
+which will refer to all versions of the same object.
 
-When an object is updated, a new revision is created. This allows one to easily keep track
-of the changes to an object over time (its *audit trail*). This means that a database key
-such as an auto-assigned ID is relatively meaningless in referring to an object, as it
-will only point to a revision.
+When an object is updated, a new revision is created. This allows one to easily
+keep track of the changes to an object over time (its *audit trail*). This
+means that a database key such as an auto-assigned ID is relatively meaningless
+in referring to an object, as it will only point to a revision.
 
-Instead, a revision can be referred to by its unique compound key (UUID, revision), where
-revision is a number which refers to the position of that version of the object in the
-audit trail (where 1 is the original version from object creation, 2 is created after the
-first update, etc.). This revision number is re-used between objects.
+A revision can be referred to by its unique compound key (UUID, revision),
+where revision is a number which refers to the position of that version of the
+object in the audit trail (where 1 is the original version from object
+creation, 2 is created after the first update, etc.). This revision number is
+re-used between objects.
 
 -------------
 
@@ -84,16 +88,15 @@ GET Endpoints
 
     [
       {
-         "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
-         "name":"Ganeti Web Manager",
-         "slugs":["gwm", "ganeti"],
-         "owner": "example-user",
-         "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
-         "revision": 2,
-         "id": 1
-         "deleted_at": null,
-         "parent": null,
-         "updated_at": null
+        "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
+        "name":"Ganeti Web Manager",
+        "slugs":["gwm", "ganeti"],
+        "owner": "example-user",
+        "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+        "created_at": 2014-04-17,
+        "deleted_at": null,
+        "updated_at": 2014-04-19,
+        "revision": 2,
       },
       {...},
       ...
@@ -104,16 +107,15 @@ GET Endpoints
 .. code-block:: javascript
 
     {
-       "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
-       "name":"Ganeti Web Manager",
-       "slugs":["ganeti", "gwm"],
-       "owner": "example-user",
-       "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
-       "revision": 4,
-       "id": 1,
-       "deleted_at": null,
-       "parent": null,
-       "updated_at": null
+      "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
+      "name":"Ganeti Web Manager",
+      "slugs":["ganeti", "gwm"],
+      "owner": "example-user",
+      "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+      "revision": 4,
+      "created_at": 2014-07-17,
+      "deleted_at": null,
+      "updated_at": 2014-07-20,
     }
 
 *GET /activities*
@@ -121,17 +123,16 @@ GET Endpoints
 .. code-block:: javascript
 
     [
-        {
-           "name":"Documentation",
-           "slugs":["docs", "doc"],
-           "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
-           "revision": 1,
-           "id": 1
-           "deleted_at": null,
-           "parent": null,
-           "updated_at": null
-        },
-        {...}
+      {
+        "name":"Documentation",
+        "slugs":["docs", "doc"],
+        "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
+        "revision": 1,
+        "created_at": 2014-04-17,
+        "deleted_at": null,
+        "updated_at": null,
+      },
+      {...}
     ]
 
 *GET /activities/<slug>*
@@ -139,14 +140,13 @@ GET Endpoints
 .. code-block:: javascript
 
     {
-       "name":"Documentation",
-       "slugs":["doc", "docs"],
-       "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
-       "revision": 5,
-       "id": 1,
-       "deleted_at": null,
-       "parent": null,
-       "updated_at": null
+      "name":"Documentation",
+      "slugs":["doc", "docs"],
+      "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
+      "revision": 5,
+      "created_at": 2014-04-17,
+      "deleted_at": null,
+      "updated_at": null,
     }
 
 *GET /times*
@@ -162,13 +162,11 @@ GET Endpoints
         "notes":"Worked on documentation toward settings configuration.",
         "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
         "date_worked":2014-04-17,
+        "revision": 1,
         "created_at":2014-04-17,
         "updated_at":null,
-        "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
-        "revision": 1,
-        "id": 1
         "deleted_at": null,
-        "parent": null
+        "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
       },
       {...}
     ]
@@ -187,11 +185,9 @@ GET Endpoints
       "date_worked":2014-06-12,
       "created_at":2014-06-12,
       "updated_at":2014-06-13,
+      "deleted_at": null,
       "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
       "revision": 3,
-      "id": 1,
-      "deleted_at": null,
-      "parent": null
     }
 
 In addition, the endpoint at ``/times`` also supports several querystring
@@ -210,9 +206,107 @@ These are accessed via
 * ``/times?start=:date``: Filters to dates after and including the given date.
 * ``/times?end=:date``:  Filters to dates after and including the given date.
 * ``/times/?archived=:bool``: Filters on objects with ``deleted_at`` set to
-  ``null`` or a date.
+  ``null`` or a date. Includes a ``parent`` field in the return object which
+  stores a list of revisions; the 0th element isthe most recent revision of the
+  object.
 
-.. note:: Dates are in ISO-8601 format.
+For example:
+
+``GET /projects/<slug>?archived=true``:
+
+.. code-block:: javascript
+
+    {
+      "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
+      "name":"Ganeti Web Manager",
+      "slugs":["ganeti", "gwm"],
+      "owner": "example-user",
+      "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+      "revision": 4,
+      "created_at": 2015-04-17,
+      "deleted_at": null,
+      "updated_at": null,
+      "parent":
+      [
+        {
+          "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
+          "name":"Ganeti Web Manager",
+          "slugs":["ganeti", "gwm"],
+          "owner": "example-user",
+          "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+          "revision": 3,
+          "created_at": 2015-04-16,
+          "deleted_at": 2015-04-17,
+          "updated_at": 2015-04-17
+        },
+        {...},
+        {...},
+      ],
+    }
+
+``GET /times/<uuid>?archived=true``:
+
+.. code-block:: javascript
+
+    {
+      "duration":20,
+      "user": "example-user",
+      "project": "gwm",
+      "activities": ["doc", "research"],
+      "notes":"Worked on documentation toward settings configuration.",
+      "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
+      "date_worked":2015-04-17,
+      "created_at":2014-06-12,
+      "updated_at":2015-04-18,
+      "uuid": aa800862-e852-4a40-8882-9b4a79aa3015,
+      "deleted_at": null,
+      "revision":2,
+      "parent":
+        [
+          {
+            "duration":20,
+            "user": "example-user",
+            "project": "gwm",
+            "activities": ["doc", "research"],
+            "notes":"Worked on documentation toward settings configuration.",
+            "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
+            "date_worked":2015-04-17,
+            "created_at":2014-06-12,
+            "updated_at":null,
+            "uuid": aa800862-e852-4a40-8882-9b4a79aa3015,
+            "deleted_at": 2014-04-18,
+            "revision":1,
+          },
+        ],
+    }
+
+``GET /activities/<slug>?archived=true``
+
+.. code-block:: javascript
+
+    {
+      "name":"Testing Infra",
+      "slugs":["testing", "test"],
+      "updated_at": 2015-04-18,
+      "uuid": 3cf78d25-411c-4d1f-80c8-a09e5e12cae3,
+      "created_at": 2014-04-17,
+      "deleted_at": null,
+      "updated_at": 2014-04-18,
+      "revision":2,
+      "parent":
+        [
+          {
+            "name":"Testing Infrastructure",
+            "slugs":["testing", "tests"],
+            "created_at": 2015-04-17,
+            "deleted_at": 2015-04-18,
+            "updated_at": null,
+            "uuid": 3cf78d25-411c-4d1f-80c8-a09e5e12cae3,
+            "deleted_at": null,
+            "revision":1,
+          }
+        ]
+    }
 
 When multiple different parameters are used, they narrow down the result set
 (for example, ``/times?user=example-user&activity=dev`` will return all time
@@ -221,36 +315,21 @@ development). When the same parameter is repeated, they expand the result set
 (for example, ``/times?activity=gwm&activity=pgd`` will return all time entries
 which were either for gwm OR pgd). Date ranges are inclusive on both ends.
 
-If a query parameter is provided with a bad value (e.g. invalid slug, or date
-not in ISO-8601 format), a Bad Query Value error is returned.
-
-Any query parameter other than those specified in this document will be
-ignored.
+* If a query parameter is provided with a bad value (e.g. invalid slug, or date
+  not in ISO-8601 format), a Bad Query Value error is returned.
+* Any query parameter other than those specified in this document will be
+  ignored.
+* For more information about errors, check the
+  :ref:`draft_errors<new-hire-checklist>`_ docs.
 
 If multiple ``start`` or ``end`` parameters are provided, the first one sent is
 used. If a query parameter is not provided, it defaults to 'all values'.
 
-The endpoint at ``/times/:uuid`` also supports several querystring parameters:
+.. note::
 
-* action
-* revision
-
-The ``action`` parameter can take one of three values:
-
-* recent (default)
-* trail
-* version
-
-If ``action`` is ``recent`` (or is not provided), the most recent revision of the object
-is returned.
-
-If it is ``trail``, the most recent revision of the object is returned, also
-containing a ``parent`` field, which will be a list of previous versions in reverse
-chronological order (i.e. the most recent revision at index 0, etc.), similar to the
-structure returned from /times.
-
-If ``action`` is ``version`` and a value for ``revision`` is provided, that revision of
-the object is returned.
+    All endpoints (``/activites/``, ``/activities/:slug``, ``/projects/``,
+    ``/projects/:slug``, ``/times/``, ``/times/:uuid``) support the
+    ``?archived`` flag which will show the full audit trail of an object.
 
 --------------
 
@@ -282,10 +361,12 @@ Response body:
        "uri":"https://code.osuosl.org/projects/timesync",
        "name":"TimeSync API",
        "slugs":["timesync", "time"],
-       "owner": "example-2",
-       "id": 1,
+       "owner":"example-2",
+       "uuid":b35f9531-517f-47bd-aab4-14298bb19555,
+       "created_at":2014-04-17,
        "updated_at":null,
-       "parent":null
+       "deleted_at":null,
+       "revision":1,
     }
 
 *POST /activities/*
@@ -307,10 +388,11 @@ Response body:
     {
        "name":"Quality Assurance/Testing",
        "slugs":["qa", "test"],
+       "uuid": cfa07a4f-d446-4078-8d73-2f77560c35c0,
+       "created_at": 2014-04-17,
        "updated_at": 2014-04-18,
-       "id": 1,
        "deleted_at": null,
-       "parent": null
+       "revision":2,
     }
 
 
@@ -344,16 +426,16 @@ Response body:
       "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/56",
       "date_worked":2014-04-17,
       "created_at":2014-04-17,
-      "updated_at": 2014-04-18,
-      "id": 1,
+      "updated_at": null,
       "deleted_at": null,
-      "parent": null
+      "uuid": 838853e3-3635-4076-a26f-7efe4e60981f,
+      "revision":1,
     },
 
-Likewise, if you'd like to edit an existing object, POST to
-*/<object name>/<slug>* (or for time objects, */times/<id>*) with a JSON body.
-The object only needs to contain the part that is being updated. The response
-body will contain the saved object, as shown above.
+Likewise, if you'd like to edit an existing object, POST to ``/<object
+name>/<slug>`` (or for time objects, ``/times/<uuid>``) with a JSON body.  The
+object only needs to contain the part that is being updated. The response body
+will contain the saved object, as shown above.
 
 
 *POST /projects/<slug>*
@@ -377,10 +459,11 @@ Response body:
       "name":"Ganeti Webmgr",
       "slugs":["webmgr", "gwm"],
       "owner": "example-user",
+      "created_at": 2014-04-16,
       "updated_at": 2014-04-18,
-      "id": 2,
       "deleted_at": null,
-      "parent": 1
+      "uuid": 309eae69-21dc-4538-9fdc-e6892a9c4dd4,
+      "revision":2,
     }
 
 *POST /activities/<slug>*
@@ -402,14 +485,15 @@ Response body:
     {
       "name":"Testing Infra",
       "slugs":["testing", "test"],
-      "updated_at": 2015-04-18,
-      "id": 4,
+      "uuid": 3cf78d25-411c-4d1f-80c8-a09e5e12cae3,
+      "created_at": 2014-04-16,
+      "updated_at": 2014-04-17,
       "deleted_at": null,
-      "parent": 2
+      "revision":2,
     }
 
 *POST /times/<uuid>*
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Request body:
 
@@ -435,9 +519,9 @@ Response body:
       "date_worked":2015-04-17,
       "created_at":2014-06-12,
       "updated_at":2015-04-18,
-      "id": 3,
       "deleted_at": null,
-      "parent": 1
+      "uuid": aa800862-e852-4a40-8882-9b4a79aa3015,
+      "revision":2,
     }
 
 
@@ -464,8 +548,10 @@ The following content is checked by the API for validity:
 .. note::
 
    When an object is updated it's ``parent`` is soft-deleted and a copy is
-   created with the new information. This results in the object having a new
-   ``id`` as well as the updated information specifed in the POST request.
+   created with the new information. This results in the object having an
+   incremented 'revision' field the updated information specifed in the POST
+   request.
+
 
 ----------------
 

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -26,8 +26,9 @@ Responses will be returned in standard JSON format. Multiple results will be
 sent as a list of JSON objects. Order of results is not guaranteed. Single
 results will be a single JSON object.
 
-Throughout this API, any form of dates will use a simplified ISO-8601 format, as `defined
-by ECMA International. <http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15>`_
+Throughout this API, any form of dates will use a simplified ISO-8601 format,
+as `defined by ECMA International.
+<http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15>`_
 
 --------
 
@@ -453,6 +454,12 @@ The following content is checked by the API for validity:
     ``[]`` will be ignored when sent to the api as the value of an object
     variable.
 
+.. note::
+
+   When an object is updated it's ``parent`` is soft-deleted and a copy is
+   created with the new information. This results in the object having a new id
+   as well as the updated information specifed in the POST request.
+
 ----------------
 
 DELETE Endpoints
@@ -467,11 +474,11 @@ an object with that UUID/slug should succeed, and completely overwrite the
 deleted object, if it still exists in the database. To an end user, it should
 appear as though the object truly does not exist.
 
-If the object exists, the API will return a 200 OK status with an empty
-response body.
+If the object exists and the ``?archived=true`` parameter is not passed, the
+API will return a 200 OK status with an empty response body.
 
-If the object does not exist, the API will return an Object Not Found error
-(see error docs).
+If the object does not exist and the ``?archived=true`` parameter is not
+passed, the API will return an Object Not Found error (see error docs).
 
 In case of any other error, the API will return a Server Error (see error
 docs).
@@ -481,9 +488,10 @@ docs).
 Authorization and Roles
 -----------------------
 
-Each timesync user can be of one of two roles: user, and admin. Admins have special
-permissions, including adding, updating, and deleting activities and projects, creating
-and promoting users, as well as acting as automatic managers/viewers of all projects.
+Each timesync user can be of one of two roles: user, and admin. Admins have
+special permissions, including adding, updating, and deleting activities and
+projects, creating and promoting users, as well as acting as automatic
+managers/viewers of all projects.
 
 In addition, each user has a role within each project to which they belong:
 
@@ -497,26 +505,26 @@ These roles exist independently, and are defined by their permissions:
 * a data viewer may view time entries
 * a project manager may update the project information.
 
-A user may be a member, viewer, or manager of multiple projects, and a project may have
-multiple members, viewers, and managers.
+A user may be a member, viewer, or manager of multiple projects, and a project
+may have multiple members, viewers, and managers.
 
-If a user attempts to access an endpoint which they are not authorized for, the server
-will return an Authorization Failure.
+If a user attempts to access an endpoint which they are not authorized for, the
+server will return an Authorization Failure.
 
 *GET Endpoints*
 ~~~~~~~~~~~~~~~
 
-GET endpoints do not have authorization at this time, and so any user can request data
-from a GET endpoint.
+GET endpoints do not have authorization at this time, and so any user can
+request data from a GET endpoint.
 
 *POST and DELETE Endpoints*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-POST /activities, POST /activities/:slug, and DELETE /activities/:slug are all only
-accessible to admin users.
+POST /activities, POST /activities/:slug, and DELETE /activities/:slug are all
+only accessible to admin users.
 
 POST /projects and DELETE /projects/:slug are only accessible to admin users.
 POST /projects/:slug is accessible to that project's manager(s).
 
-POST /times is accessible to that project's member(s), given that the 'user' field of
-the posted time is the user authenticating.
+POST /times is accessible to that project's member(s), given that the 'user'
+field of the posted time is the user authenticating.

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -92,7 +92,8 @@ GET Endpoints
          "revision": 2,
          "id": 1
          "deleted_at": null,
-         "parent": null
+         "parent": null,
+         "updated_at": null
       },
       {...},
       ...
@@ -111,7 +112,8 @@ GET Endpoints
        "revision": 4,
        "id": 1,
        "deleted_at": null,
-       "parent": null
+       "parent": null,
+       "updated_at": null
     }
 
 *GET /activities*
@@ -126,7 +128,8 @@ GET Endpoints
            "revision": 1,
            "id": 1
            "deleted_at": null,
-           "parent": null
+           "parent": null,
+           "updated_at": null
         },
         {...}
     ]
@@ -142,7 +145,8 @@ GET Endpoints
        "revision": 5,
        "id": 1,
        "deleted_at": null,
-       "parent": null
+       "parent": null,
+       "updated_at": null
     }
 
 *GET /times*
@@ -158,7 +162,7 @@ GET Endpoints
         "notes":"Worked on documentation toward settings configuration.",
         "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
         "date_worked":2014-04-17,
-        "created_at":2014-04-17T16:30,
+        "created_at":2014-04-17,
         "updated_at":null,
         "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
         "revision": 1,
@@ -303,6 +307,7 @@ Response body:
     {
        "name":"Quality Assurance/Testing",
        "slugs":["qa", "test"],
+       "updated_at": 2014-04-18,
        "id": 1,
        "deleted_at": null,
        "parent": null
@@ -320,7 +325,7 @@ Request body:
       "duration":12,
       "user": "example-2",
       "project": "Ganeti Web Manager",
-      "activities": ["gwm", "ganeti"],
+      "activities": ["documenting"],
       "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
       "date_worked":2014-04-17,
@@ -332,18 +337,18 @@ Response body:
 
     {
       "duration":12,
-      "user": "example-user",
+      "user": "example-2",
       "project": "Ganeti Web Manager",
-      "activities": ["docs", "planning"],
+      "activities": ["documenting"],
       "notes":"Worked on documentation toward settings configuration.",
-      "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
+      "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/56",
       "date_worked":2014-04-17,
-      "created_at":2014-04-17T16:30,
-      "updated_at":null,
-      "deleted_at":null,
-      "parent":null
+      "created_at":2014-04-17,
+      "updated_at": 2014-04-18,
       "id": 1,
-    }
+      "deleted_at": null,
+      "parent": null
+    },
 
 Likewise, if you'd like to edit an existing object, POST to
 */<object name>/<slug>* (or for time objects, */times/<id>*) with a JSON body.
@@ -372,6 +377,7 @@ Response body:
       "name":"Ganeti Webmgr",
       "slugs":["webmgr", "gwm"],
       "owner": "example-user",
+      "updated_at": 2014-04-18,
       "id": 2,
       "deleted_at": null,
       "parent": 1
@@ -396,6 +402,7 @@ Response body:
     {
       "name":"Testing Infra",
       "slugs":["testing", "test"],
+      "updated_at": 2015-04-18,
       "id": 4,
       "deleted_at": null,
       "parent": 2
@@ -426,8 +433,8 @@ Response body:
       "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
       "date_worked":2015-04-17,
-      "created_at":2014-06-12T16:30,
-      "updated_at":2015-04-18T16:30,
+      "created_at":2014-06-12,
+      "updated_at":2015-04-18,
       "id": 3,
       "deleted_at": null,
       "parent": 1
@@ -457,8 +464,8 @@ The following content is checked by the API for validity:
 .. note::
 
    When an object is updated it's ``parent`` is soft-deleted and a copy is
-   created with the new information. This results in the object having a new id
-   as well as the updated information specifed in the POST request.
+   created with the new information. This results in the object having a new
+   ``id`` as well as the updated information specifed in the POST request.
 
 ----------------
 

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -309,10 +309,6 @@ Response body:
       "notes":"",
       "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
       "date_worked":null,
-      "created_at":2014-09-18,
-      "updated_at":null,
-      "deleted_at":null,
-      "parent":null,
     }
 
 Likewise, if you'd like to edit an existing object, POST to

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -77,6 +77,26 @@ object in the audit trail (where 1 is the original version from object
 creation, 2 is created after the first update, etc.). This revision number is
 re-used between objects.
 
+----------------
+
+Auditing History
+----------------
+
+There are three variables in all objects that assist in an audit process
+(vewing revisions of an object through it's history).
+
+* ``created_at``: the date at which a given object (specified by a uuid) was
+  created.
+* ``updated_at``: The date at which an object was modified (the created_at date
+  of a new object revision).
+* ``deleted_at``: When the DELETE operation was performed on an object (either
+  the object is deleted or depricated for a new version of the object).
+  Depricated version of an object will include a deleted_at field but will
+  appear in an audit trail (the ``parent`` field of an object)
+
+**To view the audit trail of an object pass the ``?revisions=true`` parameter
+to any endpoint.**
+
 -------------
 
 GET Endpoints
@@ -92,7 +112,7 @@ GET Endpoints
         "name":"Ganeti Web Manager",
         "slugs":["gwm", "ganeti"],
         "owner": "example-user",
-        "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+        "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
         "created_at": 2014-04-17,
         "deleted_at": null,
         "updated_at": 2014-04-19,
@@ -111,7 +131,7 @@ GET Endpoints
       "name":"Ganeti Web Manager",
       "slugs":["ganeti", "gwm"],
       "owner": "example-user",
-      "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+      "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
       "revision": 4,
       "created_at": 2014-07-17,
       "deleted_at": null,
@@ -126,7 +146,7 @@ GET Endpoints
       {
         "name":"Documentation",
         "slugs":["docs", "doc"],
-        "uuid": adf036f5-3d49-4a84-bef9-062b46380bbf,
+        "uuid": "adf036f5-3d49-4a84-bef9-062b46380bbf",
         "revision": 1,
         "created_at": 2014-04-17,
         "deleted_at": null,
@@ -166,7 +186,7 @@ GET Endpoints
         "created_at":2014-04-17,
         "updated_at":null,
         "deleted_at": null,
-        "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
+        "uuid": "c3706e79-1c9a-4765-8d7f-89b4544cad56",
       },
       {...}
     ]
@@ -186,17 +206,17 @@ GET Endpoints
       "created_at":2014-06-12,
       "updated_at":2014-06-13,
       "deleted_at": null,
-      "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
+      "uuid": "c3706e79-1c9a-4765-8d7f-89b4544cad56",
       "revision": 3,
     }
 
 In addition, the endpoint at ``/times`` also supports several querystring
 parameters:
 
-* user,
-* project,
-* activity, and
-* date range.
+* user
+* project
+* activity
+* date range
 
 These are accessed via
 
@@ -205,10 +225,9 @@ These are accessed via
 * ``/times?activity=:activityslug``: Filters based on activity slug
 * ``/times?start=:date``: Filters to dates after and including the given date.
 * ``/times?end=:date``:  Filters to dates after and including the given date.
-* ``/times/?archived=:bool``: Filters on objects with ``deleted_at`` set to
-  ``null`` or a date. Includes a ``parent`` field in the return object which
-  stores a list of revisions; the 0th element isthe most recent revision of the
-  object.
+* ``/times/?revisions=:bool``: Returns objects and an audit list for that
+  object in the form of a list ``parent``.
+
 
 For example:
 
@@ -221,7 +240,7 @@ For example:
       "name":"Ganeti Web Manager",
       "slugs":["ganeti", "gwm"],
       "owner": "example-user",
-      "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+      "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
       "revision": 4,
       "created_at": 2015-04-17,
       "deleted_at": null,
@@ -233,7 +252,7 @@ For example:
           "name":"Ganeti Web Manager",
           "slugs":["ganeti", "gwm"],
           "owner": "example-user",
-          "uuid": a034806c-00db-4fe1-8de8-514575f31bfb,
+          "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
           "revision": 3,
           "created_at": 2015-04-16,
           "deleted_at": 2015-04-17,
@@ -258,7 +277,7 @@ For example:
       "date_worked":2015-04-17,
       "created_at":2014-06-12,
       "updated_at":2015-04-18,
-      "uuid": aa800862-e852-4a40-8882-9b4a79aa3015,
+      "uuid": "aa800862-e852-4a40-8882-9b4a79aa3015",
       "deleted_at": null,
       "revision":2,
       "parent":
@@ -273,7 +292,7 @@ For example:
             "date_worked":2015-04-17,
             "created_at":2014-06-12,
             "updated_at":null,
-            "uuid": aa800862-e852-4a40-8882-9b4a79aa3015,
+            "uuid": "aa800862-e852-4a40-8882-9b4a79aa3015",
             "deleted_at": 2014-04-18,
             "revision":1,
           },
@@ -288,7 +307,7 @@ For example:
       "name":"Testing Infra",
       "slugs":["testing", "test"],
       "updated_at": 2015-04-18,
-      "uuid": 3cf78d25-411c-4d1f-80c8-a09e5e12cae3,
+      "uuid": "3cf78d25-411c-4d1f-80c8-a09e5e12cae3",
       "created_at": 2014-04-17,
       "deleted_at": null,
       "updated_at": 2014-04-18,
@@ -301,7 +320,7 @@ For example:
             "created_at": 2015-04-17,
             "deleted_at": 2015-04-18,
             "updated_at": null,
-            "uuid": 3cf78d25-411c-4d1f-80c8-a09e5e12cae3,
+            "uuid": "3cf78d25-411c-4d1f-80c8-a09e5e12cae3",
             "deleted_at": null,
             "revision":1,
           }
@@ -320,7 +339,7 @@ which were either for gwm OR pgd). Date ranges are inclusive on both ends.
 * Any query parameter other than those specified in this document will be
   ignored.
 * For more information about errors, check the
-  :ref:`draft_errors<new-hire-checklist>`_ docs.
+  :ref:`draft_errors<draft_errors>` docs.
 
 If multiple ``start`` or ``end`` parameters are provided, the first one sent is
 used. If a query parameter is not provided, it defaults to 'all values'.
@@ -362,7 +381,7 @@ Response body:
        "name":"TimeSync API",
        "slugs":["timesync", "time"],
        "owner":"example-2",
-       "uuid":b35f9531-517f-47bd-aab4-14298bb19555,
+       "uuid":"b35f9531-517f-47bd-aab4-14298bb19555",
        "created_at":2014-04-17,
        "updated_at":null,
        "deleted_at":null,
@@ -388,7 +407,7 @@ Response body:
     {
        "name":"Quality Assurance/Testing",
        "slugs":["qa", "test"],
-       "uuid": cfa07a4f-d446-4078-8d73-2f77560c35c0,
+       "uuid": "cfa07a4f-d446-4078-8d73-2f77560c35c0",
        "created_at": 2014-04-17,
        "updated_at": 2014-04-18,
        "deleted_at": null,
@@ -406,7 +425,7 @@ Request body:
     {
       "duration":12,
       "user": "example-2",
-      "project": "Ganeti Web Manager",
+      "project": "ganet_web_manager",
       "activities": ["documenting"],
       "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
@@ -420,7 +439,7 @@ Response body:
     {
       "duration":12,
       "user": "example-2",
-      "project": "Ganeti Web Manager",
+      "project": "ganet_web_manager",
       "activities": ["documenting"],
       "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/56",
@@ -428,7 +447,7 @@ Response body:
       "created_at":2014-04-17,
       "updated_at": null,
       "deleted_at": null,
-      "uuid": 838853e3-3635-4076-a26f-7efe4e60981f,
+      "uuid": "838853e3-3635-4076-a26f-7efe4e60981f",
       "revision":1,
     },
 
@@ -462,7 +481,7 @@ Response body:
       "created_at": 2014-04-16,
       "updated_at": 2014-04-18,
       "deleted_at": null,
-      "uuid": 309eae69-21dc-4538-9fdc-e6892a9c4dd4,
+      "uuid": "309eae69-21dc-4538-9fdc-e6892a9c4dd4",
       "revision":2,
     }
 
@@ -485,7 +504,7 @@ Response body:
     {
       "name":"Testing Infra",
       "slugs":["testing", "test"],
-      "uuid": 3cf78d25-411c-4d1f-80c8-a09e5e12cae3,
+      "uuid": "3cf78d25-411c-4d1f-80c8-a09e5e12cae3",
       "created_at": 2014-04-16,
       "updated_at": 2014-04-17,
       "deleted_at": null,
@@ -520,7 +539,7 @@ Response body:
       "created_at":2014-06-12,
       "updated_at":2015-04-18,
       "deleted_at": null,
-      "uuid": aa800862-e852-4a40-8882-9b4a79aa3015,
+      "uuid": "aa800862-e852-4a40-8882-9b4a79aa3015",
       "revision":2,
     }
 

--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -157,7 +157,7 @@ GET Endpoints
         "notes":"Worked on documentation toward settings configuration.",
         "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
         "date_worked":2014-04-17,
-        "created_at":2014-04-17,
+        "created_at":2014-04-17T16:30,
         "updated_at":null,
         "uuid": c3706e79-1c9a-4765-8d7f-89b4544cad56,
         "revision": 1,
@@ -337,7 +337,7 @@ Response body:
       "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osu-cass/whats-fresh-api/issues/56",
       "date_worked":2014-04-17,
-      "created_at":2014-04-17,
+      "created_at":2014-04-17T16:30,
       "updated_at":null,
       "deleted_at":null,
       "parent":null
@@ -425,8 +425,8 @@ Response body:
       "notes":"Worked on documentation toward settings configuration.",
       "issue_uri":"https://github.com/osuosl/ganeti_webmgr/issues/40",
       "date_worked":2015-04-17,
-      "created_at":2014-06-12,
-      "updated_at":2015-04-18,
+      "created_at":2014-06-12T16:30,
+      "updated_at":2015-04-18T16:30,
       "id": 3,
       "deleted_at": null,
       "parent": 1


### PR DESCRIPTION
projects, activities, and times now have the 'deleted_at' and 'parent'
field for storing if they are an updated object ('parent' refers to the
original object) and if the object is deleted_at (which refers to if an
object has been archived or not).

There were also some miscellaneous formatting changes.
