### PR TITLE
Clarify ``POST /projects/:slug`` effects with slugs.

### DIFF
--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -488,6 +488,11 @@ Response body:
       "revision":2,
     }
 
+If a project is sent to ``/project/<slug>`` with the ``slugs`` field unset (i.e. equal to
+``undefined``), the slugs remain unchanged (similar to not passing any other field). If
+the ``slugs`` field is set, however, to an empty array, this will clear the slugs field,
+and set it equal to the empty array.
+
 *POST /activities/<slug>*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As it stands, it is unclear what will happen when the `slugs` field of the sent project is set to certain values such as undefined or an empty array. This clarifies that.
