### PR TITLE
Removed owner from projects to replace with manager.

### DIFF
--- a/source/draft_api.rst
+++ b/source/draft_api.rst
@@ -113,7 +113,6 @@ GET Endpoints
         "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
         "name":"Ganeti Web Manager",
         "slugs":["gwm", "ganeti"],
-        "owner": "example-user",
         "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
         "created_at": "2014-04-17",
         "deleted_at": null,
@@ -132,7 +131,6 @@ GET Endpoints
       "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
       "name":"Ganeti Web Manager",
       "slugs":["ganeti", "gwm"],
-      "owner": "example-user",
       "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
       "revision": 4,
       "created_at": "2014-07-17",
@@ -279,7 +277,6 @@ For example:
       "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
       "name":"Ganeti Web Manager",
       "slugs":["ganeti", "gwm"],
-      "owner": "example-user",
       "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
       "revision": 4,
       "created_at": "2015-04-16",
@@ -291,7 +288,6 @@ For example:
           "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
           "name":"Ganeti Web Manager",
           "slugs":["ganeti", "gwm"],
-          "owner": "example-user",
           "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
           "revision": 3,
           "created_at": "2015-04-16",
@@ -437,7 +433,6 @@ objects matching the query, both current and deleted.
         "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
         "name":"Ganeti Web Manager",
         "slugs":["ganeti", "gwm"],
-        "owner": "example-user",
         "uuid": "a034806c-00db-4fe1-8de8-514575f31bfb",
         "revision": 4,
         "created_at": "2014-04-17",
@@ -450,7 +445,6 @@ objects matching the query, both current and deleted.
         "uri":"https:://github.com/osuosl/timesync",
         "name":"Timesync",
         "slugs":["ts", "timesync"],
-        "owner": "example-user",
         "uuid": "1f8788bd-0909-4397-be2c-79047f90c575",
         "revision": 1,
         "created_at": "2014-04-17",
@@ -504,8 +498,7 @@ Request body:
     {
        "uri":"https://code.osuosl.org/projects/timesync",
        "name":"TimeSync API",
-       "slugs":["timesync", "time"],
-       "owner": "example-2"
+       "slugs":["timesync", "time"]
     }
 
 Response body:
@@ -516,13 +509,16 @@ Response body:
        "uri":"https://code.osuosl.org/projects/timesync",
        "name":"TimeSync API",
        "slugs":["timesync", "time"],
-       "owner":"example-2",
        "uuid":"b35f9531-517f-47bd-aab4-14298bb19555",
        "created_at":"2014-04-17",
        "updated_at":null,
        "deleted_at":null,
        "revision":1,
     }
+
+Note that this endpoint, when called, will automatically set the currently authenticated
+user as a member, spectator, and manager of the project, allowing them to update and
+delete the project, add members to it, and promote/demote user roles on the project.
 
 *POST /activities/*
 ~~~~~~~~~~~~~~~~~~~
@@ -603,8 +599,7 @@ Request body:
     {
        "uri":"https://code.osuosl.org/projects/timesync",
        "name":"TimeSync API",
-       "slugs":["timesync", "time"],
-       "owner": "example-2"
+       "slugs":["timesync", "time"]
     }
 
 Response body:
@@ -615,7 +610,6 @@ Response body:
       "uri":"https://code.osuosl.org/projects/ganeti-webmgr",
       "name":"Ganeti Webmgr",
       "slugs":["webmgr", "gwm"],
-      "owner": "example-user",
       "created_at": "2014-04-16",
       "updated_at": "2014-04-18",
       "deleted_at": null,

--- a/source/draft_model.rst
+++ b/source/draft_model.rst
@@ -57,14 +57,13 @@ notes        string           false          Other notes the user wishes to prov
 Projects
 --------
 
-=====  ==============   =============  =============================  ========================================
-Name        Type        POST Required           Description                             Notes
-=====  ==============   =============  =============================  ========================================
+=====  ==============   =============  =============================  =============================
+Name        Type        POST Required           Description                       Notes
+=====  ==============   =============  =============================  =============================
 name   string           true           The name of the project
 slugs  array of slugs   true           Slugs to identify the project  Must be unique to the project
 uri    URI              false          The URI of the project
-owner  username         true           The owner of the project       Automatically granted ``manager`` rights
-=====  ==============   =============  =============================  ========================================
+=====  ==============   =============  =============================  =============================
 
 ----------
 

--- a/source/usage/administration.rst
+++ b/source/usage/administration.rst
@@ -22,10 +22,6 @@ easier:
 * a ``uri``: a uri linking to the project's homepage.
 * a ``name``: this is the full name of the project that should be displayed
   to the user.
-* a ``creator``: this should be the original creator of the project, generally
-  an admin user. The creator acts as the default project manager and is the
-  only person that can modify the project until they (or another admin) assigns
-  project managers.
 * a list of ``slugs``: these are generally short things that people can refer
   to the project with. If your project is named Protein Geometry Database,
   it makes users' lives easier to only need to type in ``pgd`` when submitting


### PR DESCRIPTION
The `owner` field on projects was deprecated several months ago. This will remove the owner permanently, to replace it with the project manager role. Companion to https://github.com/osuosl/timesync-node/pull/215, as a part of https://github.com/osuosl/timesync-node/issues/214.
